### PR TITLE
Add FrameCoach to Utilities

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -279,6 +279,7 @@ Useful software or links that help with certain problems
 
 - [Adobe Digital Negative Converter](https://helpx.adobe.com/photoshop/digital-negative.html) - Adobe DNG Converter makes it possible to easily convert camera-specific raw files, from supported cameras to the more universal DNG raw file format.
 - [CloudConvert](https://cloudconvert.com) - CloudConvert is an online file converter.
+- [FrameCoach](https://framecoach.io) - Real-time camera coaching app for filmmakers and photographers — guides you through camera settings, composition, and shot choices.
 - [ImageOptim](https://imageoptim.com) - Removes bloated metadata. Saves disk space & bandwidth by compressing images without losing quality.
 - [Linktree](https://linktr.ee) - Connect audiences to all your content with one link.
 - [Mixkit](https://mixkit.co) - High-quality stock videos that are completely free..


### PR DESCRIPTION
## Summary

- Adds [FrameCoach](https://framecoach.io) to the **Utilities** section.
- FrameCoach is a real-time camera coaching app for filmmakers and photographers that guides you through camera settings, composition, and shot choices.

## Why this belongs here

The Utilities section contains tools that help photographers with various tasks. FrameCoach is a practical on-set companion that coaches photographers and filmmakers through camera settings (exposure, white balance, ISO) and composition rules in real time — helping them capture better shots.

## Format

- Follows the existing `[Name](url) - Description.` format
- Placed alphabetically between CloudConvert and ImageOptim